### PR TITLE
Add cli wrapper

### DIFF
--- a/taibun/__main__.py
+++ b/taibun/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/taibun/cli.py
+++ b/taibun/cli.py
@@ -1,0 +1,46 @@
+import argparse
+import sys
+from taibun import Converter, Tokeniser
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog='taibun',
+        description='Taiwanese Hokkien transliterator and tokeniser',
+    )
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    convert = subparsers.add_parser('convert', help='transliterate text into the chosen transliteration system')
+    convert.add_argument('input', nargs='+')
+    convert.add_argument(
+        '-s', '--system', default='Tailo',
+        choices=['Tailo', 'POJ', 'Zhuyin', 'TLPA', 'Pingyim', 'Tongiong', 'IPA'],
+        help='transliteration system (default: Tailo)',
+    )
+    convert.add_argument(
+        '-d', '--dialect', default='south',
+        choices=['south', 'north', 'singapore'],
+        help='dialect variant (default: south)',
+    )
+    convert.add_argument(
+        '-f', '--format', default='mark',
+        choices=['mark', 'number', 'strip'],
+        help='tone representation (default: mark)',
+    )
+
+    tokenise = subparsers.add_parser('tokenise', help='split text into word tokens')
+    tokenise.add_argument('input', nargs='+')
+    tokenise.add_argument(
+        '--no-keep-original', dest='keep_original', action='store_false', default=True,
+        help='normalise tokens to traditional characters instead of preserving original input',
+    )
+
+    args = parser.parse_args()
+
+    text = args.input if args.input is not None else sys.stdin.read()
+
+    if args.command == 'convert':
+        c = Converter(args.system, args.dialect, args.format)
+        print(c.get(text))
+    else:
+        tokens = Tokeniser(keep_original=args.keep_original).tokenise(text)
+        print('\n'.join(tokens))


### PR DESCRIPTION
Hello, I'm trying to learn Taigi right now, and I found your Taibun transliterator website pretty useful, especially the TTS feature which lets me hear the words and especially tone sandhi in context. Awesome work by the way!

I found that there was also a Python library, so I added a simple CLI wrapper which could be useful for quick usage in the shell (there's a text segmentation / morphological analyzer for Japanese called [MeCab](https://github.com/shogo82148/mecab) which is primarily CLI driven)

```
usage: taibun [-h] {convert,tokenise} ...

Taiwanese Hokkien transliterator and tokeniser

taibun convert:
  -s, --system {Tailo,POJ,Zhuyin,TLPA,Pingyim,Tongiong,IPA}
                        transliteration system (default: Tailo)
  -d, --dialect {south,north,singapore}
                        dialect variant (default: south)
  -f, --format {mark,number,strip}
                        tone representation (default: mark)

taibun tokenise:
  --no-keep-original  normalise tokens to traditional characters instead of preserving original input
```

Examples:
```
$ taibun convert '我今仔日想欲去買菜' # (default: -s Tailo -d south)
Guá kin-á-ji̍t siūnn-beh khì bé tshài

$ taibun convert '我今仔日想欲去買菜' -s POJ
Góa kin-á-ji̍t siūⁿ-beh khì bé chhài

$ taibun convert '我今仔日想欲去買菜' -s Zhuyin
ㆣㄨㄚˋ ㄍㄧㄣ ㄚˋ ㆢㄧㆵ˙ ㄒㄧㆫ˫ ㆠㆤㆷ ㄎㄧ˪ ㆠㆤˋ ㄘㄞ˪

$ taibun convert '我今仔日想欲去買菜' -s TLPA -d north
Gua2 kin1 a2 lit8 siunn7 bueh4 khi3 bue2 chai3
```

